### PR TITLE
Update eval.py

### DIFF
--- a/metrics/eval.py
+++ b/metrics/eval.py
@@ -43,6 +43,7 @@ def calculate_metrics(nets, args, step, mode):
                                          img_size=args.img_size,
                                          batch_size=args.val_batch_size,
                                          imagenet_normalize=False,
+                                         num_workers=args.num_workers,
                                          drop_last=True)
 
         for src_idx, src_domain in enumerate(src_domains):
@@ -50,7 +51,8 @@ def calculate_metrics(nets, args, step, mode):
             loader_src = get_eval_loader(root=path_src,
                                          img_size=args.img_size,
                                          batch_size=args.val_batch_size,
-                                         imagenet_normalize=False)
+                                         imagenet_normalize=False,
+                                         num_workers=args.num_workers)
 
             task = '%s2%s' % (src_domain, trg_domain)
             path_fake = os.path.join(args.eval_dir, task)


### PR DESCRIPTION
Hi 👋,

We find the num_workers parameter for data_loader is important in some environments such as docker or limited RAM, otherwise causing failure. So we add num_workers when evaluating.

--- 

For example,
In docker environment, the shared memory is limited causing specific error:
```
RuntimeError: DataLoader worker (pid xxxx) is killed by signal: Bus error. It is possible that dataloader's workers are out of shared memory. Please try to raise your shared memory limit.
```
References:
https://github.com/pytorch/pytorch/issues/5040
https://github.com/ultralytics/yolov3/issues/1151